### PR TITLE
Set the static_crt option to be consistent with MSVC runtime flags.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -36,14 +36,14 @@ class ExpatConan(ConanFile):
 
         cmake = CMake(self)
 
-        cmake_args = { "BUILD_doc" : "OFF",
-                       "BUILD_examples" : "OFF",
-                       "BUILD_shared" : self.options.shared,
-                       "BUILD_tests" : "OFF",
-                       "BUILD_tools" : "OFF",
+        cmake_args = { "EXPAT_BUILD_DOCS" : "OFF",
+                       "EXPAT_BUILD_EXAMPLES" : "OFF",
+                       "EXPAT_SHARED_LIBS" : self.options.shared,
+                       "EXPAT_BUILD_TESTS" : "OFF",
+                       "EXPAT_BUILD_TOOLS" : "OFF",
                        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
                        "CMAKE_DEBUG_POSTFIX": "",
-                       "MSVC_USE_STATIC_CRT": self.options.static_crt,
+                       "EXPAT_MSVC_STATIC_CRT": self.options.static_crt,
                      }
 
         cmake.configure(source_dir="../libexpat/expat", build_dir="build", defs=cmake_args)

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,8 +42,12 @@ class ExpatConan(ConanFile):
                        "EXPAT_BUILD_TESTS" : "OFF",
                        "EXPAT_BUILD_TOOLS" : "OFF",
                        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-                       "CMAKE_DEBUG_POSTFIX": "",
                        "EXPAT_MSVC_STATIC_CRT": self.options.static_crt,
+                       "CMAKE_DEBUG_POSTFIX": "",
+                       "CMAKE_RELEASE_POSTFIX": "",
+                       "CMAKE_MINSIZEREL_POSTFIX": "",
+                       "CMAKE_RELWITHDEBINFO_POSTFIX": "",
+  
                      }
 
         cmake.configure(source_dir="../libexpat/expat", build_dir="build", defs=cmake_args)

--- a/conanfile.py
+++ b/conanfile.py
@@ -68,4 +68,6 @@ class ExpatConan(ConanFile):
             self.cpp_info.defines = ["XML_STATIC"]
 
     def configure(self):
+        if self.settings.compiler == 'Visual Studio':
+            self.options.static_crt = (self.settings.compiler.runtime in ["MT", "MTd"])
         del self.settings.compiler.libcxx

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1.3)
 project(PackageTest C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 if (UNIX)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
@@ -14,9 +14,7 @@ if (UNIX)
     endif ()
 endif ()
 
-find_package(EXPAT REQUIRED)
+#find_package(EXPAT REQUIRED)
 
 add_executable(example example.c)
-target_link_libraries(example PRIVATE ${EXPAT_LIBRARY})
-target_include_directories(example PRIVATE ${EXPAT_INCLUDE_DIRS})
-target_compile_definitions(example PRIVATE "-DXML_STATIC")
+target_link_libraries(example PRIVATE CONAN_PKG::Expat)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 project(PackageTest C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Under Microsoft Visual studio, this flag will determine whether or not the static runtime is being used, so set the option accordingly in configure().